### PR TITLE
feat(docker): add Dockerfile and workflow for building the contracts container

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -15,8 +15,6 @@ permissions:
 
 jobs:
   docker-ghcr-push:
-    needs: check-version
-    if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     uses: phylaxsystems/actions/.github/workflows/release-docker-ghcr.yaml@main
     with:
       rust-binary-name: contracts-utils-${{ github.ref_name }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -1,0 +1,24 @@
+name: Docker GHCR Push - Contracts Utils
+
+on:
+  push:
+    branches:
+    - main
+    - linea
+    tags:
+      - "*.*.*"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  docker-ghcr-push:
+    needs: check-version
+    if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
+    uses: phylaxsystems/actions/.github/workflows/release-docker-ghcr.yaml@main
+    with:
+      rust-binary-name: contracts-utils-${{ github.ref_name }}
+      requires-private-deps: false
+      dockerfile-path: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.2
+FROM ubuntu:24.04 AS base
+ARG VERSION=v1.3.4
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    wget \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download forge and cast to be present
+RUN wget https://github.com/foundry-rs/foundry/releases/download/${VERSION}/foundry_${VERSION}_alpine_amd64.tar.gz && \
+    tar -xvzf foundry_${VERSION}_alpine_amd64.tar.gz -C /usr/local/bin forge cast && \
+    rm foundry_${VERSION}_alpine_amd64.tar.gz
+
+FROM base AS builder
+WORKDIR /app
+
+COPY . .
+
+RUN forge install && forge build
+
+LABEL org.opencontainers.image.title="credible-utility"
+LABEL org.opencontainers.image.description="Image containing utilities for Credible Smart contracts"
+LABEL org.opencontainers.image.version="0.1.0"
+LABEL org.opencontainers.image.authors="devops@phylax.watch"
+LABEL org.opencontainers.image.url="git@github.com:phylaxsystems/credible-layer-contracts"
+LABEL org.opencontainers.image.source="git@github.com:phylaxsystems/credible-layer-contracts"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="Phylax Systems"
+LABEL maintainer="devops@phylax.watch"
+LABEL version="0.1.0"
+LABEL description="mage containing utilities for Credible Smart contracts"
+
+CMD ["bash"]


### PR DESCRIPTION
# Description

This PR enables building a Docker container that has the credible contracts + forge/cast. It's used to deploy contracts in Docker/K8s environments.

The build is triggered on different branches resulting in different images