### PR TITLE
chore(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,14 @@ jobs:
           path: artifacts/
   release-npm:
     needs: create-artifacts
+    permissions:
+      contents: read
+      id-token: write
     uses: phylaxsystems/actions/.github/workflows/release-npm.yaml@main
     with:
       artifact_name: credible-layer-contracts-artifacts
       artifacts_path: artifacts/
       ignore_scripts: true
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-github:
     needs: create-artifacts
     permissions:


### PR DESCRIPTION
Migrates package releases to npm trusted publishing by granting OIDC permission and removing `NPM_TOKEN` forwarding. Depends on https://github.com/phylaxsystems/actions/pull/107 and requires the npm trusted publisher for `phylaxsystems/credible-layer-contracts` to use workflow `release.yml`.