### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phylax-systems/credible-layer-contracts",
   "description": "Smart contracts for the Credible Layer protocol",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "",
   "author": {
     "name": "Phylax Systems",


### PR DESCRIPTION
Bumps the npm package version to 0.3.0 in preparation for the next release. Contract code, ABI artifacts, and deployment behavior are unchanged.