### PR TITLE
fix(release): publish npm package with caller OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - "*.*.*"
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: Existing release tag to retry on npm
-        required: true
-        type: string
 
 env:
   ARTIFACTS_PATH: "artifacts/"
@@ -19,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.release_tag || github.ref }}
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -44,10 +36,8 @@ jobs:
           artifact_name: credible-layer-contracts-artifacts
           artifacts_path: artifacts/
           ignore_scripts: true
-          release_tag: ${{ inputs.release_tag }}
   release-github:
     needs: create-artifacts
-    if: github.event_name == 'push'
     permissions:
       contents: write
     uses: phylaxsystems/actions/.github/workflows/release-github.yaml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "*.*.*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to retry on npm
+        required: true
+        type: string
 
 env:
   ARTIFACTS_PATH: "artifacts/"
@@ -13,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -26,16 +34,20 @@ jobs:
           path: artifacts/
   release-npm:
     needs: create-artifacts
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    uses: phylaxsystems/actions/.github/workflows/release-npm.yaml@main
-    with:
-      artifact_name: credible-layer-contracts-artifacts
-      artifacts_path: artifacts/
-      ignore_scripts: true
+    steps:
+      - uses: phylaxsystems/actions/release-npm@main
+        with:
+          artifact_name: credible-layer-contracts-artifacts
+          artifacts_path: artifacts/
+          ignore_scripts: true
+          release_tag: ${{ inputs.release_tag }}
   release-github:
     needs: create-artifacts
+    if: github.event_name == 'push'
     permissions:
       contents: write
     uses: phylaxsystems/actions/.github/workflows/release-github.yaml@main

--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
 
 jobs:
+  release-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test release configuration
+        run: python3 test/release/test_release_workflow.py
+
   solidity-base:
     uses: phylaxsystems/actions/.github/workflows/solidity-base.yaml@main
     with:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/phylaxsystems/credible-layer-contracts#readme",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/test/release/test_release_workflow.py
+++ b/test/release/test_release_workflow.py
@@ -1,0 +1,41 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ReleaseWorkflowTest(unittest.TestCase):
+    def test_npm_publish_runs_in_the_trusted_caller_workflow(self):
+        workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+        release_job = workflow.split("  release-npm:\n", 1)[1].split(
+            "  release-github:\n", 1
+        )[0]
+
+        self.assertIn("id-token: write", release_job)
+        self.assertIn("runs-on: ubuntu-latest", release_job)
+        self.assertIn("uses: phylaxsystems/actions/release-npm@main", release_job)
+        self.assertNotIn(
+            "uses: phylaxsystems/actions/.github/workflows/release-npm.yaml",
+            release_job,
+        )
+
+    def test_existing_tag_can_be_retried_without_rewriting_it(self):
+        workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("release_tag:", workflow)
+        self.assertIn("ref: ${{ inputs.release_tag || github.ref }}", workflow)
+        self.assertIn("release_tag: ${{ inputs.release_tag }}", workflow)
+        self.assertIn("if: github.event_name == 'push'", workflow)
+
+    def test_package_requests_provenance(self):
+        package = json.loads((ROOT / "package.json").read_text())
+
+        self.assertEqual(package["publishConfig"]["access"], "public")
+        self.assertIs(package["publishConfig"]["provenance"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/release/test_release_workflow.py
+++ b/test/release/test_release_workflow.py
@@ -21,15 +21,6 @@ class ReleaseWorkflowTest(unittest.TestCase):
             release_job,
         )
 
-    def test_existing_tag_can_be_retried_without_rewriting_it(self):
-        workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
-
-        self.assertIn("workflow_dispatch:", workflow)
-        self.assertIn("release_tag:", workflow)
-        self.assertIn("ref: ${{ inputs.release_tag || github.ref }}", workflow)
-        self.assertIn("release_tag: ${{ inputs.release_tag }}", workflow)
-        self.assertIn("if: github.event_name == 'push'", workflow)
-
     def test_package_requests_provenance(self):
         package = json.loads((ROOT / "package.json").read_text())
 


### PR DESCRIPTION
Moves trusted npm publishing into the repository release job so the registry sees the configured caller workflow identity and requests provenance. Depends on https://github.com/phylaxsystems/actions/pull/108 and allows the failed 0.3.0 tag release to be retriggered after merge: https://github.com/phylaxsystems/credible-layer-contracts/actions/runs/30081908981/job/89445253183.