### PR TITLE
fix(release): publish npm package inline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,27 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: phylaxsystems/actions/release-npm@main
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          artifact_name: credible-layer-contracts-artifacts
-          artifacts_path: artifacts/
-          ignore_scripts: true
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # npm >= 11.5.1 is required for OIDC trusted publishing.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: credible-layer-contracts-artifacts
+          path: artifacts/
+
+      - name: Publish to npm
+        run: npm publish --access public --ignore-scripts=true
   release-github:
     needs: create-artifacts
     permissions:

--- a/test/release/test_release_workflow.py
+++ b/test/release/test_release_workflow.py
@@ -7,7 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class ReleaseWorkflowTest(unittest.TestCase):
-    def test_npm_publish_runs_in_the_trusted_caller_workflow(self):
+    def test_npm_publish_runs_inline_in_the_trusted_workflow(self):
         workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
         release_job = workflow.split("  release-npm:\n", 1)[1].split(
             "  release-github:\n", 1
@@ -15,11 +15,17 @@ class ReleaseWorkflowTest(unittest.TestCase):
 
         self.assertIn("id-token: write", release_job)
         self.assertIn("runs-on: ubuntu-latest", release_job)
-        self.assertIn("uses: phylaxsystems/actions/release-npm@main", release_job)
-        self.assertNotIn(
-            "uses: phylaxsystems/actions/.github/workflows/release-npm.yaml",
-            release_job,
+        self.assertIn("uses: actions/checkout@", release_job)
+        self.assertIn("uses: actions/setup-node@", release_job)
+        self.assertIn("registry-url: https://registry.npmjs.org", release_job)
+        self.assertIn("run: npm install -g npm@latest", release_job)
+        self.assertIn("uses: actions/download-artifact@", release_job)
+        self.assertIn("name: credible-layer-contracts-artifacts", release_job)
+        self.assertIn("path: artifacts/", release_job)
+        self.assertIn(
+            "run: npm publish --access public --ignore-scripts=true", release_job
         )
+        self.assertNotIn("phylaxsystems/actions/release-npm", release_job)
 
     def test_package_requests_provenance(self):
         package = json.loads((ROOT / "package.json").read_text())


### PR DESCRIPTION
Publishes the npm package directly from the top-level release workflow so npm trusted publishing sees the configured release.yml OIDC identity. The existing artifact and GitHub release flow stays unchanged, with a regression check preventing the shared npm action from being reintroduced.