### PR TITLE
fix(ci): validate state oracle v2 with deployable settings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,9 @@ optimizer = true
 optimizer_runs = 200
 evm_version = "cancun"
 
+[profile.snapshot]
+no_match_test = "^invariant_"
+
 [lint]
 exclude_lints = ["mixed-case-function", "mixed-case-variable"]
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,11 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
+[profile.ci]
+optimizer = true
+optimizer_runs = 200
+evm_version = "cancun"
+
 [lint]
 exclude_lints = ["mixed-case-function", "mixed-case-variable"]
 


### PR DESCRIPTION
Relates to ENG-4250

Aligns CI compilation with the optimized Cancun settings used for V2 deployments and excludes stateful invariant functions from gas snapshots while preserving them in the normal test suite. This makes bytecode-size checks representative and avoids Foundry snapshot comparator failures.